### PR TITLE
Luxe support

### DIFF
--- a/src/hxDaedalus/graphics/Pixels.hx
+++ b/src/hxDaedalus/graphics/Pixels.hx
@@ -114,26 +114,43 @@ abstract Pixels(PixelsData)
 
 #end
 
-#if (snow || luxe) // in snow/luxe texture bytes are in RGBA format
+#if (snow || luxe) // in snow/luxe texture bytes are in RGBA format (and must account for power_of_two sizes)
 	
-	@:from static public function fromSnowTexture(texture:phoenix.Texture) {
+	@:from static public function fromLuxeTexture(texture:phoenix.Texture) {
 		var pixels = new Pixels(texture.width, texture.height, true);
 		pixels.format = PixelFormat.RGBA;
 		
+		var pot_w = texture.width_actual;
 		var data:snow.io.typedarray.Uint8Array = texture.asset.image.data;
 		
-		for (i in 0...pixels.bytes.length) {
-			pixels.bytes.set(i, data[i]);
+		var i = 0;
+		for (y in 0...pixels.height) {
+			for (x in 0...pixels.width) {
+				var pos:Int = (x << 2) + (y << 2) * pot_w;
+				pixels.bytes.set(i++, data[pos + 0]);
+				pixels.bytes.set(i++, data[pos + 1]);
+				pixels.bytes.set(i++, data[pos + 2]);
+				pixels.bytes.set(i++, data[pos + 3]);
+			}
 		}
 		
 		return pixels;
 	}
 	
-	public function applyToSnowTexture(texture:phoenix.Texture) {
+	public function applyToLuxeTexture(texture:phoenix.Texture) {
+		
+		var pot_w = texture.width_actual;
 		var data:snow.io.typedarray.Uint8Array = texture.asset.image.data;
 		
-		for (i in 0...this.bytes.length) {
-			data[i] = this.bytes.get(i);
+		var i = 0;
+		for (y in 0...this.height) {
+			for (x in 0...this.width) {
+				var pos:Int = (x << 2) + (y << 2) * pot_w;
+				data[pos + 0] = this.bytes.get(i++);
+				data[pos + 1] = this.bytes.get(i++);
+				data[pos + 2] = this.bytes.get(i++);
+				data[pos + 3] = this.bytes.get(i++);
+			}
 		}
 		texture.reset();  // rebind texture
 	}

--- a/src/hxDaedalus/graphics/Pixels.hx
+++ b/src/hxDaedalus/graphics/Pixels.hx
@@ -1,56 +1,67 @@
 package hxDaedalus.graphics;
 
 import haxe.io.Bytes;
-import haxe.io.BytesData;
 
 
 /**
  * Class abstracting pixels for various libs/targets (for easier manipulation).
- * The underlying bytes will be in ARGB format (and implicitly converted to that when needed).
+ * 
+ * The exposed get/set methods will transparently work in ARGB format, while
+ * the underlying bytes' pixel format will be automatically inferenced when one 
+ * of the `from_` methods is called.
+ * 
+ * You can still override the channel mapping by setting `format` afterwards.
  * 
  * @author azrafe7
  */
 @:forward
 abstract Pixels(PixelsData)
 {
+	static inline var CHANNEL_MASK:Int = 3;
+	
 	/** 
 	 * Constructor. If `alloc` is false no memory will be allocated for `bytes`, 
-	 * but the other properties (width, height, length) will still be set.
+	 * but the other properties (width, height, count) will still be set.
 	 */
 	inline public function new(width:Int, height:Int, alloc:Bool = true) 
 	{
 		this = new PixelsData(width, height, alloc);
 	}
 	
+	/** Byte value at `i` position, as if the data were in ARGB format. */
 	inline public function getByte(i:Int) {
-		return this.bytes.get(i);
+		return this.bytes.get((i & ~CHANNEL_MASK) + this.format.channelMap[i & CHANNEL_MASK]);
 	}
 	
+	/** Pixel value (without alpha) at `x`,`y`, as if the data were in ARGB format. */
 	inline public function getPixel(x:Int, y:Int) {
 		var pos = (y * this.width + x) << 2;
 		
-		var r = this.bytes.get(pos + 1) << 16;
-		var g = this.bytes.get(pos + 2) << 8;
-		var b = this.bytes.get(pos + 3);
+		var r = this.bytes.get(pos + this.format.R) << 16;
+		var g = this.bytes.get(pos + this.format.G) << 8;
+		var b = this.bytes.get(pos + this.format.B);
 		
 		return r | g | b;
 	}
 	
+	/** Pixel value (with alpha) at `x`,`y`, as if the data were in ARGB format. */
 	inline public function getPixel32(x:Int, y:Int) {
 		var pos = (y * this.width + x) << 2;
 		
-		var a = this.bytes.get(pos + 0) << 24;
-		var r = this.bytes.get(pos + 1) << 16;
-		var g = this.bytes.get(pos + 2) << 8;
-		var b = this.bytes.get(pos + 3);
+		var a = this.bytes.get(pos + this.format.A) << 24;
+		var r = this.bytes.get(pos + this.format.R) << 16;
+		var g = this.bytes.get(pos + this.format.G) << 8;
+		var b = this.bytes.get(pos + this.format.B);
 		
 		return a | r | g | b;
 	}
 	
+	/** Sets the byte value at `i` pos, as if the data were in ARGB format. */
 	inline public function setByte(i:Int, value:Int) {
-		this.bytes.set(i, value);
+		this.bytes.set((i & ~CHANNEL_MASK) + this.format.channelMap[i & CHANNEL_MASK], value);
 	}
 	
+	/** Sets the pixel value (without alpha) at `x`,`y`, with `value` expressed in RGB format. */
 	inline public function setPixel(x:Int, y:Int, value:Int) {
 		var pos = (y * this.width + x) << 2;
 		
@@ -58,11 +69,12 @@ abstract Pixels(PixelsData)
 		var g = (value >> 8) & 0xFF;
 		var b = (value) & 0xFF;
 
-		this.bytes.set((pos + 1), r);
-		this.bytes.set((pos + 2), g);
-		this.bytes.set((pos + 3), b);
+		this.bytes.set(pos + this.format.R, r);
+		this.bytes.set(pos + this.format.G, g);
+		this.bytes.set(pos + this.format.B, b);
 	}
 	
+	/** Sets the pixel value (with alpha) at `x`,`y`, with `value` expressed in ARGB format. */
 	inline public function setPixel32(x:Int, y:Int, value:Int) {
 		var pos = (y * this.width + x) << 2;
 		
@@ -71,48 +83,71 @@ abstract Pixels(PixelsData)
 		var g = (value >> 8) & 0xFF;
 		var b = (value) & 0xFF;
 
-		this.bytes.set((pos + 0), a);
-		this.bytes.set((pos + 1), r);
-		this.bytes.set((pos + 2), g);
-		this.bytes.set((pos + 3), b);
+		this.bytes.set((pos + this.format.A), a);
+		this.bytes.set((pos + this.format.R), r);
+		this.bytes.set((pos + this.format.G), g);
+		this.bytes.set((pos + this.format.B), b);
 	}
-
 	
-#if (flambe) // in flambe texture bytes are in RGBA format, and we want ARGB
+	public function clone():Pixels {
+		var clone:Pixels = new Pixels(this.width, this.height, true);
+		clone.bytes.blit(0, this.bytes, 0, this.bytes.length);
+		return clone;
+	}
+	
+#if (flambe) // in flambe texture bytes are in RGBA format
 
-	@:from static public function fromTexture(texture:flambe.display.Texture) {
+	@:from static public function fromFlambeTexture(texture:flambe.display.Texture) {
 		var pixels = new Pixels(texture.width, texture.height, false);
+		pixels.format = PixelFormat.RGBA;
 		
-		// read pixels bytes in RGBA and then convert them in place to ARGB
 		pixels.bytes = texture.readPixels(0, 0, texture.width, texture.height);
-		Converter.RGBA2ARGB(pixels.bytes);
 		
 		return pixels;
 	}
 	
 	#if (flambe && html) // not possible in (flambe && flash) due to Stage3D limitations
-	public function applyTo(texture:flambe.display.Texture) {
-		var bytesRGBA = Bytes.alloc(this.width * this.height);
-		Converter.ARGB2RGBA(this.bytes, bytesRGBA);
-		texture.writePixels(bytesRGBA, 0, 0, this.width, this.height);
+	public function applyToFlambeTexture(texture:flambe.display.Texture) {
+		texture.writePixels(this.bytes, 0, 0, this.width, this.height);
 	}
 	#end
+
+#end
+
+#if (snow || luxe) // in snow/luxe texture bytes are in RGBA format
 	
-#elseif (flash || openfl || nme || (flambe && flash))
+	@:from static public function fromSnowTexture(texture:phoenix.Texture) {
+		var pixels = new Pixels(texture.width, texture.height, true);
+		pixels.format = PixelFormat.RGBA;
+		
+		var data:snow.io.typedarray.Uint8Array = texture.asset.image.data;
+		
+		for (i in 0...pixels.bytes.length) {
+			pixels.bytes.set(i, data[i]);
+		}
+		
+		return pixels;
+	}
+	
+	public function applyToSnowTexture(texture:phoenix.Texture) {
+		var data:snow.io.typedarray.Uint8Array = texture.asset.image.data;
+		
+		for (i in 0...this.bytes.length) {
+			data[i] = this.bytes.get(i);
+		}
+		texture.reset();  // rebind texture
+	}
+#end
+
+#if (flash || openfl || nme || (flambe && flash))
 
 	@:from static public function fromBitmapData(bmd:flash.display.BitmapData) {
 	#if js	
 	
 		var pixels = new Pixels(bmd.width, bmd.height);
+		pixels.format = PixelFormat.ARGB;
 		
-		/* NOTE: alternative way, but seems slower
-		var bv = bmd.getPixels(bmd.rect).byteView;
-
-		for (i in 0...bv.length) {
-			var pos = (i % 4) != 3 ? i + 1 : i - 3; // `bv` is in RGBA and we want ARGB
-			pixels.bytes.set(pos, bv[i]);
-		}*/
-		
+		// this seems faster than other alternatives using getPixels/getVector
 		for (y in 0...pixels.height) {
 			for (x in 0...pixels.width) {
 				pixels.setPixel32(x, y, bmd.getPixel32(x, y));
@@ -122,6 +157,8 @@ abstract Pixels(PixelsData)
 	#else
 		
 		var pixels = new Pixels(bmd.width, bmd.height, false);
+		pixels.format = PixelFormat.ARGB;
+		
 		var ba = bmd.getPixels(bmd.rect);
 		
 		#if flash
@@ -135,15 +172,17 @@ abstract Pixels(PixelsData)
 		return pixels;
 	}
 	
-	@:to public function toBitmapData():flash.display.BitmapData {
-		var bmd:flash.display.BitmapData = new flash.display.BitmapData(this.width, this.height);
+	public function applyToBitmapData(bmd:flash.display.BitmapData) {
+	#if js
 		
-		return applyTo(bmd);
-	}
+		for (y in 0...this.height) {
+			for (x in 0...this.width) {
+				bmd.setPixel32(x, y, getPixel32(x, y));
+			}
+		}
+		
+	#else
 	
-	public function applyTo(bmd:flash.display.BitmapData) {
-	#if !js
-		
 		var ba = bmd.getPixels(bmd.rect);
 		
 		#if (openfl && !flash)
@@ -156,58 +195,41 @@ abstract Pixels(PixelsData)
 		ba.position = 0;
 		bmd.setPixels(bmd.rect, ba);
 		
-	#else
-	
-		for (y in 0...this.height) {
-			for (x in 0...this.width) {
-				bmd.setPixel32(x, y, getPixel32(x, y));
-			}
-		}
-		
 	#end
-	
-		return bmd;
 	}
 
-#elseif java
+#end
+
+#if java
 
 	@:from static public function fromBufferedImage(image:java.awt.image.BufferedImage) {
 		var pixels = new Pixels(image.getWidth(), image.getHeight(), true);
-		
-		var imageARGB = image;
-		
-		/* NOTE: it seems the buffer has always bytes in RGBA, so there's no need to convert
-		if (image.getType() != java.awt.image.BufferedImage.TYPE_INT_ARGB) {
-			trace("before", image.getType());
-			imageARGB = Converter.convert(image, java.awt.image.BufferedImage.TYPE_INT_ARGB);
-			trace("after", imageARGB.getType());
-		}*/
+		pixels.format = PixelFormat.RGBA;
 		
 		var buffer = new java.NativeArray<Int>(pixels.bytes.length);
-		imageARGB.getRaster().getPixels(0, 0, pixels.width, pixels.height, buffer);
+		buffer = image.getRaster().getPixels(0, 0, pixels.width, pixels.height, buffer);
 		
 		for (i in 0...buffer.length) pixels.bytes.set(i, buffer[i]);
-		Converter.RGBA2ARGB(pixels.bytes);
 		
 		return pixels;
 	}
 	
-	public function applyTo(image:java.awt.image.BufferedImage) {
+	public function applyToBufferedImage(image:java.awt.image.BufferedImage) {
 		var imageType = image.getType();
 		
-		var bytesRGBA = Bytes.alloc(this.bytes.length);
-		Converter.ARGB2RGBA(this.bytes, bytesRGBA);
-		
 		var buffer = new java.NativeArray<Int>(this.bytes.length);
-		for (i in 0...buffer.length) buffer[i] = bytesRGBA.get(i);
+		for (i in 0...buffer.length) buffer[i] = this.bytes.get(i);
 		
 		image.getRaster().setPixels(0, 0, this.width, this.height, buffer);
 	}
 
-#elseif js	// plain js - conversion from ImageData
+#end
+
+#if js	// plain js - conversion from ImageData
 
 	@:from static public function fromImageData(image:js.html.ImageData) {
 		var pixels = new Pixels(image.width, image.height, true);
+		pixels.format = PixelFormat.ARGB;
 		
 		var data = image.data;
 		
@@ -224,10 +246,12 @@ abstract Pixels(PixelsData)
 @:allow(hxDaedalus.graphics.Pixels)
 private class PixelsData
 {
-	/** Length (in pixels NOT bytes). */
-	public var length(default, null):Int;
+	inline static public var BYTES_PER_PIXEL:Int = 4;
 	
-	/** Bytes representing the pixels (in ARGB). */
+	/** Total number of pixels. */
+	public var count(default, null):Int;
+	
+	/** Bytes representing the pixels (in `format` pixel format). */
 	public var bytes(default, null):Bytes;
 	
 	/** Width of the source image. */
@@ -236,19 +260,78 @@ private class PixelsData
 	/** Height of the source image. */
 	public var height(default, null):Int;
 	
+	/** Internal pixel format. */
+	public var format:PixelFormat;
+	
 	/** 
 	 * Constructor. If `alloc` is false no memory will be allocated for `bytes`, 
-	 * but the other properties (width, height, length) will still be set.
+	 * but the other properties (width, height, count) will still be set.
+	 * 
+	 * `format` defaults to ARGB.
 	 */
-	public function new(width:Int, height:Int, alloc:Bool = true)
+	public function new(width:Int, height:Int, alloc:Bool = true, format:PixelFormat = null)
 	{
-		this.length = width * height;
+		this.count = width * height;
 		
-		if (alloc) bytes = Bytes.alloc(this.length << 2);
+		if (alloc) bytes = Bytes.alloc(this.count << 2);
 		
 		this.width = width;
 		this.height = height;
+		this.format = format != null ? format : PixelFormat.ARGB;
 	}
+}
+
+class PixelFormat {
+	
+	static public var ARGB(default, null):PixelFormat;
+	static public var RGBA(default, null):PixelFormat;
+	
+	public var channelMap(default, null):Array<Channel>;
+	
+	var name:String;
+	
+	static function __init__():Void {
+		ARGB = new PixelFormat(CH_0, CH_1, CH_2, CH_3, "ARGB");
+		RGBA = new PixelFormat(CH_3, CH_0, CH_1, CH_2, "RGBA");
+	}
+	
+	public function new(a:Channel, r:Channel, g:Channel, b:Channel, name:String = "PixelFormat"):Void {
+		this.channelMap = [a, r, g, b];
+		this.name = name;
+	}
+	
+	public var A(get, null):Int;
+	inline private function get_A():Int {
+		return channelMap[0];
+	}
+	
+	public var R(get, null):Int;
+	inline private function get_R():Int {
+		return channelMap[1];
+	}
+	
+	public var G(get, null):Int;
+	inline private function get_G():Int {
+		return channelMap[2];
+	}
+	
+	public var B(get, null):Int;
+	inline private function get_B():Int {
+		return channelMap[3];
+	}
+	
+	public function toString():String {
+		return name;
+	}
+}
+
+@:enum abstract Channel(Int) to Int {
+	var CH_0 = 0;
+	var CH_1 = 1;
+	var CH_2 = 2;
+	var CH_3 = 3;
+	
+	@:op(A + B) static function add(a:Int, b:Channel):Int;
 }
 
 class Converter
@@ -310,7 +393,7 @@ class Converter
 #if java
 
 	/** Converts `inImage` into a new image of `imageType` format. */
-	static public function convert(inImage:java.awt.image.BufferedImage, imageType:Int):java.awt.image.BufferedImage
+	static public function convertBufferedImage(inImage:java.awt.image.BufferedImage, imageType:Int):java.awt.image.BufferedImage
 	{
 		var outImage = new java.awt.image.BufferedImage(inImage.getWidth(), inImage.getHeight(), imageType);
 		var g2d = outImage.createGraphics();

--- a/src/hxDaedalus/graphics/SimpleDrawingContext.hx
+++ b/src/hxDaedalus/graphics/SimpleDrawingContext.hx
@@ -4,6 +4,8 @@ package hxDaedalus.graphics;
 typedef SimpleDrawingContext = hxDaedalus.graphics.flambe.SimpleDrawingContext;
 #elseif (flash || openfl || nme) 
 typedef SimpleDrawingContext = hxDaedalus.graphics.flash.SimpleDrawingContext;
+#elseif luxe
+typedef SimpleDrawingContext = hxDaedalus.graphics.luxe.SimpleDrawingContext;
 #elseif js
 typedef SimpleDrawingContext = hxDaedalus.graphics.js.SimpleDrawingContext;
 #elseif java

--- a/src/hxDaedalus/graphics/TargetCanvas.hx
+++ b/src/hxDaedalus/graphics/TargetCanvas.hx
@@ -4,6 +4,8 @@ package hxDaedalus.graphics;
 typedef TargetCanvas = hxDaedalus.graphics.flambe.GraphicsComponent;
 #elseif (flash || openfl || nme) 
 typedef TargetCanvas = flash.display.Graphics;
+#elseif luxe
+typedef TargetCanvas = Array<phoenix.geometry.Geometry>;
 #elseif js
 typedef TargetCanvas = hxDaedalus.canvas.BasicCanvas;
 #elseif java

--- a/src/hxDaedalus/graphics/luxe/SimpleDrawingContext.hx
+++ b/src/hxDaedalus/graphics/luxe/SimpleDrawingContext.hx
@@ -1,0 +1,103 @@
+package hxDaedalus.graphics.luxe;
+
+import hxDaedalus.graphics.ISimpleDrawingContext;
+import hxDaedalus.graphics.TargetCanvas;
+import luxe.Color;
+import luxe.Vector;
+
+
+class SimpleDrawingContext implements ISimpleDrawingContext
+{
+	public var graphics(default, null):TargetCanvas;
+
+	var _prevX:Float = 0;
+	var _prevY:Float = 0;
+	
+	var _lineColor:Color = new Color();
+	var _fillColor:Color = new Color();
+	
+	var _inFillingMode:Bool = false;
+	
+	public function new(graphics:TargetCanvas) {
+		this.graphics = graphics;
+	}
+	
+	public function clear():Void {
+		var geom;
+		while ((geom = graphics.pop()) != null) geom.drop();
+	}
+	
+	public function lineStyle(thickness:Float, color:Int, ?alpha:Float = 1):Void
+	{
+		_lineColor = new Color().rgb(color);
+		_lineColor.a = alpha;
+	}
+	
+	public function beginFill(color:Int, ?alpha:Float = 1):Void {
+		_fillColor = new Color().rgb(color);
+		_fillColor.a = alpha;
+		_inFillingMode = true;
+	}
+	
+	public function endFill():Void {
+		_inFillingMode = false;
+	}
+	
+	public function moveTo(x:Float, y:Float):Void {
+		_prevX = x;
+		_prevY = y;
+	}
+	
+	public function lineTo(x:Float, y:Float):Void {
+		var geom = Luxe.draw.line({
+			p0: new Vector(_prevX, _prevY),
+			p1: new Vector(x, y),
+			color: _lineColor
+		});
+		_prevX = x;
+		_prevY = y;
+		graphics.push(geom);
+	}
+	
+	public function drawCircle(cx:Float, cy:Float, radius:Float):Void {
+		if (_inFillingMode) {
+			var geom = Luxe.draw.circle({
+				x: cx,
+				y: cy,
+				r: radius,
+				color: _fillColor
+			});
+			graphics.push(geom);
+		}
+		
+		var geom = Luxe.draw.ring({
+			x: cx,
+			y: cy,
+			r: radius,
+			color: _lineColor
+		});
+		graphics.push(geom);
+	}
+	
+	public function drawRect(x:Float, y:Float, width:Float, height:Float):Void {
+		if (_inFillingMode) {
+			var geom = Luxe.draw.box({
+				x: x,
+				y: y,
+				w: width,
+				h: height,
+				color: _fillColor
+			});
+			graphics.push(geom);
+		}
+		
+		var geom = Luxe.draw.rectangle({
+			x: x,
+			y: y,
+			w: width,
+			h: height,
+			color: _lineColor
+		});
+		graphics.push(geom);
+	}
+}

--- a/src/hxDaedalus/view/SimpleView.hx
+++ b/src/hxDaedalus/view/SimpleView.hx
@@ -118,14 +118,7 @@ class SimpleView
         graphics.moveTo(path[0], path[1]);
         var i = 2;
         while (i < path.length) {
-            //TODO: remove these conditionals once openfl behaves consistently
-        #if (openfl && sys)
-            graphics.beginFill(0, 1);
-        #end
             graphics.lineTo(path[i], path[i + 1]);
-        #if (openfl && sys)
-            graphics.endFill();
-        #end
             graphics.moveTo(path[i], path[i + 1]);
             i += 2;
         }


### PR DESCRIPTION
This adds Luxe support to the lib:
 - to/from `Luxe.Texture` in `Pixels`
 - `TargetCanvas` maps to `Array<Geometry>`
 - `SimpleDrawingContext` mimics a simpler flash graphics API to Luxe drawing routines