### PR TITLE
Change traverse() to getVerticesAndEdges() for faster drawing...

### DIFF
--- a/src/hxDaedalus/data/Mesh.hx
+++ b/src/hxDaedalus/data/Mesh.hx
@@ -1575,8 +1575,9 @@ class Mesh
         }
     }
 	
-	public function traverse(onVertex : Vertex->Void, onEdge : Edge->Void) : Void 
+	public function getVerticesAndEdges() : { vertices:Array<Vertex>, edges:Array<Edge> }
 	{
+		var res = { vertices:[], edges:[] };
         var vertex : Vertex;
         var incomingEdge : Edge;
         var holdingFace : Face;
@@ -1595,25 +1596,23 @@ class Mesh
             if (!vertexIsInsideAABB(vertex, this)) 
                 continue;  
             
-			onVertex(vertex);
+			res.vertices.push(vertex);
             
             iterEdges.fromVertex = vertex;
             while ((incomingEdge = iterEdges.next()) != null)
             {
                 if (!dictVerticesDone[incomingEdge.originVertex]) 
                 {
-					onEdge(incomingEdge);
+					res.edges.push(incomingEdge);
                 }
             }
         }
+		return res;
 	}
     
-    public function vertexIsInsideAABB(vertex : Vertex, mesh : Mesh) : Bool 
+    inline public function vertexIsInsideAABB(vertex : Vertex, mesh : Mesh) : Bool 
 	{
-        if (vertex.pos.x < 0 || vertex.pos.x > mesh.width || vertex.pos.y < 0 || vertex.pos.y > mesh.height) 
-            return false
-        else 
-			return true;
+        return !(vertex.pos.x < 0 || vertex.pos.x > mesh.width || vertex.pos.y < 0 || vertex.pos.y > mesh.height); 
     }
 }
 

--- a/src/hxDaedalus/view/SimpleView.hx
+++ b/src/hxDaedalus/view/SimpleView.hx
@@ -108,8 +108,11 @@ class SimpleView
     public function drawMesh(mesh:Mesh, cleanBefore : Bool = false):Void
 	{
         if (cleanBefore) graphics.clear();
-
-		mesh.traverse(drawVertex, drawEdge);
+		
+		var all = mesh.getVerticesAndEdges();
+		
+		for (v in all.vertices) drawVertex(v);
+		for (e in all.edges) drawEdge(e);
     }
 
     public function drawEntity(entity:EntityAI, cleanBefore:Bool = false):Void


### PR DESCRIPTION
(now returns an array of vertices and edges instead of binding the draw calls while traversing)