### PR TITLE
Improved A* pathfinding

### DIFF
--- a/src/hxDaedalus/ai/AStar.hx
+++ b/src/hxDaedalus/ai/AStar.hx
@@ -177,8 +177,21 @@ class AStar {
                     
                     fromPoint.x = entryX[ curFace ];
                     fromPoint.y = entryY[ curFace ];
-                    entryPoint.x = ( innerEdge.originVertex.pos.x + innerEdge.destinationVertex.pos.x ) / 2;
-                    entryPoint.y = ( innerEdge.originVertex.pos.y + innerEdge.destinationVertex.pos.y ) / 2;
+
+                    // entryPoint will be the direct point of intersection between fromPoint and toXY if the edge innerEdge
+                    // intersects it
+                    var vw1 : Point2D = innerEdge.originVertex.pos;
+                    var vw2 : Point2D = innerEdge.destinationVertex.pos;
+                    if (!Geom2D.intersections2segments(fromPoint.x, fromPoint.y, toX, toY, vw1.x, vw1.y, vw2.x, vw2.y, entryPoint)) {
+                        // Recycle the entryPoint variable to create a Point2D(toX, toY)
+                        entryPoint.x = toX;
+                        entryPoint.y = toY;
+                        var vst = vw1.distanceSquaredTo(fromPoint) + vw1.distanceSquaredTo(entryPoint);
+                        var wst = vw2.distanceSquaredTo(fromPoint) + vw2.distanceSquaredTo(entryPoint);
+                        entryPoint.x = vst <= wst ? vw1.x : vw2.x;
+                        entryPoint.y = vst <= wst ? vw1.y : vw2.y;
+                    }
+
                     distancePoint.x = entryPoint.x - toX;
                     distancePoint.y = entryPoint.y - toY;
                     h = distancePoint.length;

--- a/src/hxDaedalus/data/math/Point2D.hx
+++ b/src/hxDaedalus/data/math/Point2D.hx
@@ -50,4 +50,10 @@ class Point2D{
         var diffY : Float = y - p.y;
         return Math.sqrt( diffX*diffX + diffY*diffY );
     }
+
+    public function distanceSquaredTo( p: Point2D ): Float {
+        var diffX : Float = x - p.x;
+        var diffY : Float = y - p.y;
+        return diffX*diffX + diffY*diffY;
+    }
 }


### PR DESCRIPTION
In the current iteration of the A* algorithm only the middle point of the edge to traverse is considered a waypoint. While this works relatively well for maze-like structures it fails horribly in circumnavigating obstacles, as it's easy to see also from your live demos.

While trying to improve the path finding, I opted to convert it from a middle edge navigation to a hybrid navigation system:
* if the edge is on a direct intersection between origin and destination, use the intersection as a navigation point, minimising distances in open areas, allowing direct traversal with LoS
* if the edge is out of the direct path, find the closest edge vertex (presumably a corner) to turn around of.

![Path test](https://user-images.githubusercontent.com/284077/83328897-ba1cfa00-a286-11ea-8b62-257641875529.gif)

This test has been made reproducing the [Pathfinding](https://rawgit.com/hxDaedalus/hxDaedalus-Examples/master/hxDaedalus-Examples/web/DaedalusPathfinding.html) structure, and the box the character is going around to is the top-left most.

It also mantains (and possibly slightly improves) the distance in the maze:

![Maze](https://user-images.githubusercontent.com/284077/83328972-1253fc00-a287-11ea-99f7-12274081714b.png)